### PR TITLE
Improve stem 1.7+ compatibility by handling stem.OperationFailed on GETINFO failure

### DIFF
--- a/prometheus-tor-exporter.py
+++ b/prometheus-tor-exporter.py
@@ -82,7 +82,7 @@ class StemCollector:
                                             labels=["fingerprint"])
             fingerprint.add_metric([fingerprint_value], 1)
             yield fingerprint
-        except stem.ProtocolError:
+        except (stem.ProtocolError, stem.OperationFailed):
             # happens when not running in server mode
             pass
         nickname = GaugeMetricFamily("tor_nickname",


### PR DESCRIPTION
As described in the [stem 1.7 ChangeLog](https://stem.torproject.org/change_log.html#version-1-7):
> get_info() commonly raised stem.ProtocolError when it should provide a stem.OperationFailed

Handle both to be compatible with more recent stem libraries (1.7 was released 2 months ago).